### PR TITLE
Add glue-factory training adapter for MambaGlue

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 - [Tested Environment](#desktop_computer-tested-environment)
 - [Install](#keyboard-install)
 - [Quickstart](#zap-quickstart)
-- [Training and Evaluation (coming soon)](#dart-training-and-evaluation-glue-factory-branch-coming-soon)
+- [Training (experimental reproduction)](#dart-training-experimental-reproduction)
 - [Visualization with hloc (coming soon)](#magic_wand-visualization-and-evaluation-hloc-branch-coming-soon)
 - [FAQ](#question-faq)
 - [To Do](#clipboard-to-do)
@@ -38,12 +38,14 @@
 
 
 ## MambaGlue :snake:
-The `main` branch contains the standard MambaGlue model and inference utilities. Training, evaluation, and SfM/visual-localization workflows will be provided on two dedicated branches, built on top of [CVG Lab](https://cvg.ethz.ch/)'s codebases:
+The `main` branch contains:
 
-- `glue-factory` *(coming soon)*: training and benchmark evaluation, built on [Glue Factory](https://github.com/cvg/glue-factory)
-- `hloc` *(coming soon)*: SfM and visual localization, built on [Hierarchical-Localization](https://github.com/cvg/Hierarchical-Localization/)
+- the standard MambaGlue model and inference utilities (`mambaglue/`); and
+- an experimental training adapter for [Glue Factory](https://github.com/cvg/glue-factory) under `mambaglue/training/` — see [Training](#dart-training-experimental-reproduction).
 
-> **Note:** the `glue-factory` and `hloc` branches are not yet pushed to this repository. Until they are, the `main` branch only supports *inference* with released weights — training is not yet reproducible from this repo on its own. See [`#8`](https://github.com/url-kaist/MambaGlue/issues/8).
+SfM and visual-localization integration is planned for a separate `hloc` branch, built on [Hierarchical-Localization](https://github.com/cvg/Hierarchical-Localization/).
+
+> **Note:** the `hloc` branch is not yet pushed. The training pipeline is functional but has not yet been verified to reproduce the paper's reported numbers end-to-end — defaults are inherited from LightGlue. See [`#8`](https://github.com/url-kaist/MambaGlue/issues/8).
 
 
 ## :desktop_computer: Tested Environment
@@ -98,10 +100,30 @@ points1 = feats1["keypoints"][matches[..., 1]]       # matched keypoints in imag
 Supported front-end extractors: `superpoint`, `disk`, `aliked`, `sift` (passed via the `features=` argument). To visualize matches, see `mambaglue.viz2d`.
 
 
-## :dart: Training and Evaluation (`glue-factory` branch, coming soon)
-> :warning: **The `glue-factory` branch has not been pushed yet.** Tracked in the To-Do below.
+## :dart: Training (experimental reproduction)
 
-When released, the branch will provide a [Glue Factory](https://github.com/cvg/glue-factory) integration to train MambaGlue on any local feature extractor and to benchmark on HPatches and MegaDepth. A single training run takes roughly one week. Configs and exact commands will live on the branch's README. Until then, training is not reproducible from this repo on its own.
+The `mambaglue/training/` subpackage adds a [Glue Factory](https://github.com/cvg/glue-factory) adapter (`MambaGlueMatcher`) and two YAML configs that reproduce the paper's two-stage recipe (synthetic homographies → MegaDepth) without modifying glue-factory itself.
+
+```bash
+# 1) Install glue-factory (not on PyPI)
+pip install "git+https://github.com/cvg/glue-factory.git"
+
+# 2) Install MambaGlue with training extras
+pip install -e ".[train]"
+
+# 3) Run both stages (SuperPoint + MambaGlue)
+bash mambaglue/training/run.sh
+```
+
+The configs are 10-12 GB-tuned (batch 32 for homographies, batch 4 for MegaDepth, `bfloat16` autocast, gradient checkpointing). End-to-end training on a single RTX 3080 takes roughly a week. Target numbers from the paper (SuperPoint + MambaGlue):
+
+| Benchmark                  | Metric                  | Paper            |
+| -------------------------- | ----------------------- | ---------------- |
+| HPatches                   | PR@3px                  | 94.6             |
+| HPatches (LO-RANSAC)       | AUC@1 / 5 px            | 39.0 / 79.3      |
+| MegaDepth-1500 (LO-RANSAC) | AUC@5° / 10° / 20°      | 67.5 / 80.3 / 87.6 |
+
+The paper does not disclose optimizer, learning rate, batch size, layer count, or Mamba SSM dimensions, so defaults are inherited from LightGlue (`lr=1e-4`, AdamW, 9 layers) and from the released MambaGlue checkpoint's architecture. Treat the first run as exploratory. Mamba kernel hyperparameters (`d_state`, `d_conv`, `expand`) are hard-coded in `mambaglue.mambaglue.MambaMixer` — edit the source to sweep them.
 
 
 ## :magic_wand: Visualization and Evaluation (`hloc` branch, coming soon)
@@ -116,7 +138,7 @@ When released, the branch will integrate MambaGlue as a matcher in [Hierarchical
 The weight currently published is a pre-publication version, and the runtime environment used for the paper differs from a fresh install. To match the numbers reported in the paper, train from scratch on your target front-end and tune the inference hyperparameters (e.g. `filter_threshold`, `depth_confidence`, `width_confidence`) on a held-out split.
 
 **Q. How is MambaGlue trained?** ([#8](https://github.com/url-kaist/MambaGlue/issues/8))<br>
-Training is **not** reproducible from this repository at the moment — the `glue-factory` branch where the training pipeline lives has not yet been pushed (tracked in the To-Do below). When it is released, MambaGlue will plug into [Glue Factory](https://github.com/cvg/glue-factory) the same way LightGlue does, with the standard two-stage protocol used by SuperGlue/LightGlue (correspondence head first, then the confidence regressor used for point pruning). Dropping `mambaglue.py` into an upstream Glue Factory checkout is not a valid substitute, since the branch contains additional configs and registration glue that have not been released yet.
+The `mambaglue/training/` subpackage in this branch plugs MambaGlue into [Glue Factory](https://github.com/cvg/glue-factory) with the standard two-stage protocol used by SuperGlue/LightGlue (correspondence head first, then the confidence regressor used for point pruning). See [Training](#dart-training-experimental-reproduction) for setup and the reproduction caveats — the recipe defaults are inherited from LightGlue because the paper does not disclose them.
 
 **Q. Does MambaGlue support point pruning?** ([#5](https://github.com/url-kaist/MambaGlue/issues/5))<br>
 Yes. It is enabled with the `width_confidence` and `depth_confidence` config keys (set to a positive value to activate, `-1` to disable), the same convention as LightGlue. Pruning is auto-skipped on CPU and on small keypoint counts, where the gather overhead outweighs the savings.
@@ -126,7 +148,6 @@ Mamba's selective-scan CUDA kernels do not build on macOS. Use the provided Dock
 
 
 ## :clipboard: To Do
-- [ ] **Push the `glue-factory` branch** (training and benchmark code)
 - [ ] **Push the `hloc` branch** (SfM/visual-localization integration)
 - [ ] Push the published-version checkpoint (currently the released weight is a pre-publication version, see [#6](https://github.com/url-kaist/MambaGlue/issues/6))
 - [ ] Release demo code (notebook)

--- a/mambaglue/training/configs/superpoint+mambaglue_homography.yaml
+++ b/mambaglue/training/configs/superpoint+mambaglue_homography.yaml
@@ -1,0 +1,55 @@
+# MambaGlue + SuperPoint, stage 1: synthetic homographies pretraining.
+# Mirrors gluefactory/configs/superpoint+lightglue_homography.yaml, with the
+# matcher swapped to the MambaGlue training adapter and batch / workers
+# scaled down for a single 10-12 GB GPU (e.g. RTX 3080).
+data:
+    name: homographies
+    data_dir: revisitop1m
+    train_size: 150000
+    val_size: 2000
+    batch_size: 32
+    num_workers: 6
+    homography:
+        difficulty: 0.7
+        max_angle: 45
+    photometric:
+        name: lg
+model:
+    name: two_view_pipeline
+    extractor:
+        name: gluefactory_nonfree.superpoint
+        max_num_keypoints: 512
+        force_num_keypoints: True
+        detection_threshold: 0.0
+        nms_radius: 3
+        trainable: False
+    ground_truth:
+        name: matchers.homography_matcher
+        th_positive: 3
+        th_negative: 3
+    matcher:
+        name: mambaglue.training.matcher
+        input_dim: 256
+        descriptor_dim: 256
+        n_layers: 9
+        num_heads: 4
+        flash: false
+        checkpointed: true
+        filter_threshold: 0.1
+train:
+    seed: 0
+    epochs: 40
+    log_every_iter: 100
+    eval_every_iter: 500
+    lr: 1e-4
+    lr_schedule:
+        start: 20
+        type: exp
+        on_epoch: true
+        exp_div_10: 10
+    plot: [5, 'gluefactory.visualization.visualize_batch.make_match_figures']
+benchmarks:
+    hpatches:
+      eval:
+        estimator: opencv
+        ransac_th: 0.5

--- a/mambaglue/training/configs/superpoint+mambaglue_megadepth.yaml
+++ b/mambaglue/training/configs/superpoint+mambaglue_megadepth.yaml
@@ -1,0 +1,84 @@
+# MambaGlue + SuperPoint, stage 2: MegaDepth fine-tuning.
+# Mirrors gluefactory/configs/superpoint+lightglue_megadepth.yaml.
+#
+# Two-stage training: set `train.load_experiment` (CLI: --train.load_experiment
+# <stage1_experiment_name>) to resume from the homography pretraining run.
+#
+# 3080-tuned: batch_size 4 (was 32); enable load_features.do once features have
+# been cached, otherwise the SuperPoint extractor will sit in memory and OOM at
+# this resolution. If 1024 still OOMs, drop preprocessing.resize to 832.
+data:
+    name: megadepth
+    preprocessing:
+        resize: 1024
+        side: long
+        square_pad: True
+    train_split: train_scenes_clean.txt
+    train_num_per_scene: 300
+    val_split: valid_scenes_clean.txt
+    val_pairs: valid_pairs.txt
+    min_overlap: 0.1
+    max_overlap: 0.7
+    num_overlap_bins: 3
+    read_depth: true
+    read_image: true
+    batch_size: 4
+    num_workers: 6
+    load_features:
+        do: false  # set true after exporting SuperPoint features to save VRAM
+        path: exports/megadepth-undist-depth-r1024_SP-k2048-nms3/{scene}.h5
+        padding_length: 2048
+        padding_fn: pad_local_features
+model:
+    name: two_view_pipeline
+    extractor:
+        name: gluefactory_nonfree.superpoint
+        max_num_keypoints: 2048
+        force_num_keypoints: True
+        detection_threshold: 0.0
+        nms_radius: 3
+        trainable: False
+    matcher:
+        name: mambaglue.training.matcher
+        input_dim: 256
+        descriptor_dim: 256
+        n_layers: 9
+        num_heads: 4
+        flash: false
+        checkpointed: true
+        filter_threshold: 0.1
+    ground_truth:
+        name: matchers.depth_matcher
+        th_positive: 3
+        th_negative: 5
+        th_epi: 5
+    allow_no_extract: True
+train:
+    seed: 0
+    epochs: 50
+    log_every_iter: 100
+    eval_every_iter: 1000
+    lr: 1e-4
+    lr_schedule:
+        start: 30
+        type: exp
+        on_epoch: true
+        exp_div_10: 10
+    dataset_callback_fn: sample_new_items
+    plot: [5, 'gluefactory.visualization.visualize_batch.make_match_figures']
+benchmarks:
+    megadepth1500:
+        data:
+            preprocessing:
+                side: long
+                resize: 1600
+        eval:
+            estimator: opencv
+            ransac_th: 0.5
+    hpatches:
+        eval:
+            estimator: opencv
+            ransac_th: 0.5
+        model:
+            extractor:
+                max_num_keypoints: 1024

--- a/mambaglue/training/matcher.py
+++ b/mambaglue/training/matcher.py
@@ -1,0 +1,328 @@
+"""glue-factory-compatible MambaGlue matcher for training.
+
+This module exposes ``MambaGlueMatcher``, a ``BaseModel`` subclass that wires
+the inference-only modules from :mod:`mambaglue.mambaglue` into the data
+contract expected by ``gluefactory``'s ``two_view_pipeline`` and training
+loop. The mathematical model is unchanged from
+:class:`mambaglue.mambaglue.MambaGlue`; only the I/O shape, early-exit logic,
+gradient checkpointing, and loss head differ.
+
+Reference for the contract this matcher implements:
+``gluefactory/models/matchers/lightglue.py`` in the glue-factory repo.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.utils.checkpoint
+from torch import nn
+
+from gluefactory.models.base_model import BaseModel
+from gluefactory.models.utils.losses import NLLLoss
+from gluefactory.models.utils.metrics import matcher_metrics
+
+from ..mambaglue import (
+    LearnableFourierPositionalEncoding,
+    MatchAssignment,
+    TokenConfidence,
+    TransformerMambaLayer,
+    filter_matches,
+    normalize_keypoints,
+)
+
+
+class TrainableTokenConfidence(TokenConfidence):
+    """MambaGlue's deep confidence MLP + a LightGlue-style BCE loss head.
+
+    The inference module (``mambaglue.mambaglue.TokenConfidence``) does not ship
+    a loss method, so we subclass it and add one that mirrors the training-time
+    loss in ``gluefactory.models.matchers.lightglue.TokenConfidence``.
+    The pre-sigmoid logit is obtained by running the MLP up to, but not
+    including, the final Sigmoid.
+    """
+
+    def __init__(self, dim: int) -> None:
+        super().__init__(dim)
+        self.loss_fn = nn.BCEWithLogitsLoss(reduction="none")
+
+    def _logits(self, desc):
+        x = desc.detach()
+        for layer in list(self.token.children())[:-1]:  # skip the trailing Sigmoid
+            x = layer(x)
+        return x.squeeze(-1)
+
+    def loss(self, desc0, desc1, la_now, la_final):
+        logit0 = self._logits(desc0)
+        logit1 = self._logits(desc1)
+        la_now, la_final = la_now.detach(), la_final.detach()
+        correct0 = (
+            la_final[:, :-1, :].max(-1).indices
+            == la_now[:, :-1, :].max(-1).indices
+        )
+        correct1 = (
+            la_final[:, :, :-1].max(-2).indices
+            == la_now[:, :, :-1].max(-2).indices
+        )
+        return (
+            self.loss_fn(logit0, correct0.float()).mean(-1)
+            + self.loss_fn(logit1, correct1.float()).mean(-1)
+        ) / 2.0
+
+
+class MambaGlueMatcher(BaseModel):
+    default_conf = {
+        "name": "mambaglue_matcher",
+        "input_dim": 256,
+        "descriptor_dim": 256,
+        "add_scale_ori": False,
+        "n_layers": 9,
+        "num_heads": 4,
+        "flash": False,
+        "depth_confidence": -1,
+        "width_confidence": -1,
+        "filter_threshold": 0.0,
+        "checkpointed": True,
+        "weights": None,
+        "loss": {
+            "gamma": 1.0,
+            "fn": "nll",
+            "nll_balancing": 0.5,
+            "gamma_f": 0.0,
+        },
+    }
+
+    required_data_keys = [
+        "keypoints0",
+        "keypoints1",
+        "descriptors0",
+        "descriptors1",
+        "view0",
+        "view1",
+    ]
+
+    def _init(self, conf):
+        if conf.input_dim != conf.descriptor_dim:
+            self.input_proj = nn.Linear(
+                conf.input_dim, conf.descriptor_dim, bias=True
+            )
+        else:
+            self.input_proj = nn.Identity()
+
+        head_dim = conf.descriptor_dim // conf.num_heads
+        self.posenc = LearnableFourierPositionalEncoding(
+            2 + 2 * conf.add_scale_ori, head_dim, head_dim
+        )
+
+        h, n, d = conf.num_heads, conf.n_layers, conf.descriptor_dim
+        self.transformermambas = nn.ModuleList(
+            [TransformerMambaLayer(d, h, conf.flash) for _ in range(n)]
+        )
+        self.log_assignment = nn.ModuleList([MatchAssignment(d) for _ in range(n)])
+        self.token_confidence = nn.ModuleList(
+            [TrainableTokenConfidence(d) for _ in range(n - 1)]
+        )
+
+        self.loss_fn = NLLLoss(conf.loss)
+
+    def _forward(self, data: dict) -> dict:
+        for key in self.required_data_keys:
+            assert key in data, f"Missing key {key} in data"
+
+        kpts0, kpts1 = data["keypoints0"], data["keypoints1"]
+        b, m, _ = kpts0.shape
+        _, n, _ = kpts1.shape
+        device = kpts0.device
+
+        size0 = data["view0"].get("image_size")
+        size1 = data["view1"].get("image_size")
+        kpts0 = normalize_keypoints(kpts0, size0).clone()
+        kpts1 = normalize_keypoints(kpts1, size1).clone()
+
+        if self.conf.add_scale_ori:
+            sc0, o0 = data["scales0"], data["oris0"]
+            sc1, o1 = data["scales1"], data["oris1"]
+            kpts0 = torch.cat(
+                [
+                    kpts0,
+                    sc0 if sc0.dim() == 3 else sc0[..., None],
+                    o0 if o0.dim() == 3 else o0[..., None],
+                ],
+                -1,
+            )
+            kpts1 = torch.cat(
+                [
+                    kpts1,
+                    sc1 if sc1.dim() == 3 else sc1[..., None],
+                    o1 if o1.dim() == 3 else o1[..., None],
+                ],
+                -1,
+            )
+
+        desc0 = data["descriptors0"].contiguous()
+        desc1 = data["descriptors1"].contiguous()
+        assert desc0.shape[-1] == self.conf.input_dim
+        assert desc1.shape[-1] == self.conf.input_dim
+        if torch.is_autocast_enabled():
+            desc0 = desc0.half()
+            desc1 = desc1.half()
+
+        desc0 = self.input_proj(desc0)
+        desc1 = self.input_proj(desc1)
+        encoding0 = self.posenc(kpts0)
+        encoding1 = self.posenc(kpts1)
+
+        do_early_stop = self.conf.depth_confidence > 0 and not self.training
+        do_point_pruning = self.conf.width_confidence > 0 and not self.training
+
+        all_desc0, all_desc1 = [], []
+        if do_point_pruning:
+            ind0 = torch.arange(0, m, device=device)[None]
+            ind1 = torch.arange(0, n, device=device)[None]
+            prune0 = torch.ones_like(ind0)
+            prune1 = torch.ones_like(ind1)
+
+        token0, token1 = None, None
+        for i in range(self.conf.n_layers):
+            if self.conf.checkpointed and self.training:
+                desc0, desc1 = torch.utils.checkpoint.checkpoint(
+                    self.transformermambas[i],
+                    desc0,
+                    desc1,
+                    encoding0,
+                    encoding1,
+                    use_reentrant=False,
+                )
+            else:
+                desc0, desc1 = self.transformermambas[i](
+                    desc0, desc1, encoding0, encoding1
+                )
+            if self.training or i == self.conf.n_layers - 1:
+                all_desc0.append(desc0)
+                all_desc1.append(desc1)
+                continue
+
+            if do_early_stop:
+                assert b == 1
+                token0, token1 = self.token_confidence[i](desc0, desc1)
+                if self._check_if_stop(
+                    token0[..., :m, :], token1[..., :n, :], i, m + n
+                ):
+                    break
+            if do_point_pruning:
+                assert b == 1
+                scores0 = self.log_assignment[i].get_matchability(desc0)
+                prunemask0 = self._get_pruning_mask(token0, scores0, i)
+                keep0 = torch.where(prunemask0)[1]
+                ind0 = ind0.index_select(1, keep0)
+                desc0 = desc0.index_select(1, keep0)
+                encoding0 = encoding0.index_select(-2, keep0)
+                prune0[:, ind0] += 1
+                scores1 = self.log_assignment[i].get_matchability(desc1)
+                prunemask1 = self._get_pruning_mask(token1, scores1, i)
+                keep1 = torch.where(prunemask1)[1]
+                ind1 = ind1.index_select(1, keep1)
+                desc1 = desc1.index_select(1, keep1)
+                encoding1 = encoding1.index_select(-2, keep1)
+                prune1[:, ind1] += 1
+
+        desc0, desc1 = desc0[..., :m, :], desc1[..., :n, :]
+        scores, _ = self.log_assignment[i](desc0, desc1)
+        m0, m1, mscores0, mscores1 = filter_matches(scores, self.conf.filter_threshold)
+
+        if do_point_pruning:
+            m0_ = torch.full((b, m), -1, device=m0.device, dtype=m0.dtype)
+            m1_ = torch.full((b, n), -1, device=m1.device, dtype=m1.dtype)
+            m0_[:, ind0] = torch.where(
+                m0 == -1, -1, ind1.gather(1, m0.clamp(min=0))
+            )
+            m1_[:, ind1] = torch.where(
+                m1 == -1, -1, ind0.gather(1, m1.clamp(min=0))
+            )
+            mscores0_ = torch.zeros((b, m), device=mscores0.device)
+            mscores1_ = torch.zeros((b, n), device=mscores1.device)
+            mscores0_[:, ind0] = mscores0
+            mscores1_[:, ind1] = mscores1
+            m0, m1, mscores0, mscores1 = m0_, m1_, mscores0_, mscores1_
+        else:
+            prune0 = torch.ones_like(mscores0) * self.conf.n_layers
+            prune1 = torch.ones_like(mscores1) * self.conf.n_layers
+
+        pred = {
+            "matches0": m0,
+            "matches1": m1,
+            "matching_scores0": mscores0,
+            "matching_scores1": mscores1,
+            "ref_descriptors0": torch.stack(all_desc0, 1),
+            "ref_descriptors1": torch.stack(all_desc1, 1),
+            "log_assignment": scores,
+            "prune0": prune0,
+            "prune1": prune1,
+        }
+        return pred
+
+    def loss(self, pred, data):
+        def loss_params(pred, i):
+            la, _ = self.log_assignment[i](
+                pred["ref_descriptors0"][:, i], pred["ref_descriptors1"][:, i]
+            )
+            return {"log_assignment": la}
+
+        sum_weights = 1.0
+        nll, gt_weights, loss_metrics = self.loss_fn(loss_params(pred, -1), data)
+        N = pred["ref_descriptors0"].shape[1]
+        losses = {"total": nll, "last": nll.clone().detach(), **loss_metrics}
+
+        if self.training:
+            losses["confidence"] = 0.0
+
+        losses["row_norm"] = pred["log_assignment"].exp()[:, :-1].sum(2).mean(1)
+        for i in range(N - 1):
+            params_i = loss_params(pred, i)
+            nll, _, _ = self.loss_fn(params_i, data, weights=gt_weights)
+
+            if self.conf.loss.gamma > 0.0:
+                weight = self.conf.loss.gamma ** (N - i - 1)
+            else:
+                weight = i + 1
+            sum_weights += weight
+            losses["total"] = losses["total"] + nll * weight
+
+            losses["confidence"] += self.token_confidence[i].loss(
+                pred["ref_descriptors0"][:, i],
+                pred["ref_descriptors1"][:, i],
+                params_i["log_assignment"],
+                pred["log_assignment"],
+            ) / (N - 1)
+
+            del params_i
+        losses["total"] /= sum_weights
+
+        if self.training:
+            losses["total"] = losses["total"] + losses["confidence"]
+
+        if not self.training:
+            metrics = matcher_metrics(pred, data)
+        else:
+            metrics = {}
+        return losses, metrics
+
+    def _confidence_threshold(self, layer_index: int) -> float:
+        import numpy as np
+
+        threshold = 0.8 + 0.1 * np.exp(-4.0 * layer_index / self.conf.n_layers)
+        return float(np.clip(threshold, 0, 1))
+
+    def _get_pruning_mask(self, confidences, scores, layer_index):
+        keep = scores > (1 - self.conf.width_confidence)
+        if confidences is not None:
+            keep |= confidences <= self._confidence_threshold(layer_index)
+        return keep
+
+    def _check_if_stop(self, confidences0, confidences1, layer_index, num_points):
+        confidences = torch.cat([confidences0, confidences1], -1)
+        threshold = self._confidence_threshold(layer_index)
+        ratio_confident = 1.0 - (confidences < threshold).float().sum() / num_points
+        return ratio_confident > self.conf.depth_confidence
+
+
+__main_model__ = MambaGlueMatcher

--- a/mambaglue/training/run.sh
+++ b/mambaglue/training/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Two-stage MambaGlue + SuperPoint training via glue-factory.
+# Run from the MambaGlue repository root after `pip install -e ".[train]"` and
+# after installing glue-factory (see mambaglue/training/README.md).
+set -euo pipefail
+
+CONFIG_DIR="mambaglue/training/configs"
+
+# Stage 1: synthetic homographies pretraining
+python -m gluefactory.train sp_mambaglue_homog \
+    --conf "${CONFIG_DIR}/superpoint+mambaglue_homography.yaml" \
+    --mixed_precision bfloat16 \
+    "$@"
+
+# Stage 2: MegaDepth fine-tuning, resumed from stage 1 checkpoint
+python -m gluefactory.train sp_mambaglue_md \
+    --conf "${CONFIG_DIR}/superpoint+mambaglue_megadepth.yaml" \
+    --mixed_precision bfloat16 \
+    train.load_experiment=sp_mambaglue_homog \
+    "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,17 @@ Paper = "https://arxiv.org/abs/2502.00462"
 
 [project.optional-dependencies]
 dev = ["black==23.12.1", "flake8", "isort"]
+# Training reproduction extras. `gluefactory` itself is not installable from
+# PyPI; install it separately (editable from a local clone or directly from
+# https://github.com/cvg/glue-factory). See mambaglue/training/README.md.
+train = ["h5py", "tensorboard", "pytlsd"]
 
 [tool.setuptools]
-packages = ["mambaglue"]
+packages = ["mambaglue", "mambaglue.training"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"mambaglue.training" = ["configs/*.yaml", "run.sh"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
## Summary
- Adds `mambaglue/training/` — a glue-factory training adapter for MambaGlue that requires **no edits to glue-factory itself** (resolved via `gluefactory.models.get_model('mambaglue.training.matcher')`).
- Includes `MambaGlueMatcher` (BaseModel subclass) that reuses inference modules from `mambaglue.mambaglue`, exposes `log_assignment` + per-layer descriptors for glue-factory's NLL + confidence loss, supports gradient checkpointing, and disables early-exit / pruning during training. Adds `TrainableTokenConfidence` so MambaGlue's deep MLP confidence head has a pre-sigmoid BCE loss head.
- Two YAML configs (`superpoint+mambaglue_{homography,megadepth}.yaml`) mirroring LightGlue's two-stage recipe, tuned for a single 10–12 GB GPU (batch 32 / 4, `flash:false`, `checkpointed:true`, bf16). `run.sh` launches both stages.
- README updated with reproduction instructions, target numbers from the paper, and explicit reproducibility caveats (paper does not disclose optimizer / LR / batch / layer count, so defaults are inherited from LightGlue).

## Test plan
- [x] `python -m py_compile matcher.py` + YAML parse + bash -n run.sh
- [x] Stub-based import: `get_model('mambaglue.training.matcher')` resolves to `MambaGlueMatcher`
- [x] GPU smoke test on RTX 3080: end-to-end forward + NLL/confidence loss + AdamW backward on synthetic batch
- [x] Realistic-shape memory test (9 layers, 2048 keypoints, bf16, gradient checkpointing): peak VRAM 0.80 / 1.60 / 2.97 GB at batch 1 / 2 / 4
- [ ] One-epoch homography sanity run (requires RevisitOP1M download, not done in this PR)
- [ ] Full two-stage reproduction (target: HPatches AUC@5px ≈ 79.3, MegaDepth-1500 AUC@5° ≈ 67.5)

## Notes
- Tested env: torch 2.4.0+cu121, mamba_ssm 2.2.2, transformers 4.43.4 (mamba_ssm's `__init__.py` imports a symbol removed in transformers 4.45+).